### PR TITLE
Add battle logs

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -35,7 +35,7 @@ export async function exampleHistoricBattle() {
   game.playGame();
 }
 
-/** An example of a custom battle using cards and rules that you set */
+/** An example of a custom battle using cards and rules that you set. Returns the battle logs. */
 export async function exampleCustomBattle() {
   const allCards = await getAllCards();
   const rules = new Set<Ruleset>();
@@ -51,39 +51,40 @@ export async function exampleCustomBattle() {
   const team1 = new GameTeam(
     new GameSummoner(scarredLlamaMageCard, /* cardLevel */ 1),
     [kronGameMonster],
-    TEAM_NUMBER.FRIENDLY
+    TEAM_NUMBER.FRIENDLY,
   );
   const team2 = new GameTeam(
     new GameSummoner(scarredLlamaMageCard, /* cardLevel */ 3),
     [fleshGolemMonster],
-    TEAM_NUMBER.FRIENDLY
+    TEAM_NUMBER.FRIENDLY,
   );
 
-  const game = new Game(team1, team2, rules);
+  const game = new Game(team1, team2, rules, /* shouldLog */ true);
   game.playGame();
+  return game.getBattleLogs();
 }
 
 // You should store the cards locally so this doesn't need to be called all the time.
 async function getAllCards(): Promise<CardDetail[]> {
   return await fetch(SPLINTERLANDS_API_URL + GET_ALL_CARDS_ENDPOINT).then(
-    (response) => response.json() as Promise<CardDetail[]>
+    (response) => response.json() as Promise<CardDetail[]>,
   );
 }
 
 async function getHistoricBattle(battleId: string): Promise<BattleHistory> {
-  return await fetch(
-    SPLINTERLANDS_API_URL + BATTLE_HISTORY_ENDPOINT + battleId
-  ).then((response) => response.json() as Promise<BattleHistory>);
+  return await fetch(SPLINTERLANDS_API_URL + BATTLE_HISTORY_ENDPOINT + battleId).then(
+    (response) => response.json() as Promise<BattleHistory>,
+  );
 }
 
 function createGameTeam(
   allCards: CardDetail[],
   battleTeam: BattleTeam,
-  teamNumber: TEAM_NUMBER
+  teamNumber: TEAM_NUMBER,
 ): GameTeam {
   const gameSummoner = new GameSummoner(
     allCards[battleTeam.summoner.card_detail_id - 1],
-    battleTeam.summoner.level
+    battleTeam.summoner.level,
   );
   const gameMonsters = battleTeam.monsters.map((monster) => {
     const monsterCard = allCards[monster.card_detail_id - 1];
@@ -95,18 +96,10 @@ function createGameTeam(
 function createGame(
   allCards: CardDetail[],
   battleDetails: BattleDetails,
-  rulesets: Set<Ruleset>
+  rulesets: Set<Ruleset>,
 ): Game {
-  const gameTeam1 = createGameTeam(
-    allCards,
-    battleDetails.team1,
-    TEAM_NUMBER.FRIENDLY
-  );
-  const gameTeam2 = createGameTeam(
-    allCards,
-    battleDetails.team2,
-    TEAM_NUMBER.ENEMY
-  );
+  const gameTeam1 = createGameTeam(allCards, battleDetails.team1, TEAM_NUMBER.FRIENDLY);
+  const gameTeam2 = createGameTeam(allCards, battleDetails.team2, TEAM_NUMBER.ENEMY);
 
   return new Game(gameTeam1, gameTeam2, rulesets);
 }

--- a/index.ts
+++ b/index.ts
@@ -2,4 +2,5 @@ export { GameSummoner } from './src/game_summoner';
 export { GameMonster } from './src/game_monster';
 export { GameTeam } from './src/game_team';
 export { Game } from './src/game';
+export { GameCard } from './src/game_card';
 export * from './src/types';

--- a/src/game.ts
+++ b/src/game.ts
@@ -88,6 +88,11 @@ export class Game {
   }
 
   public getBattleLogs() {
+    if (!this.shouldLog) {
+      throw new Error(
+        'You must instantiate the Game with enableLogs as true in the constructor in order to have logs',
+      );
+    }
     return this.battleLogs;
   }
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -931,23 +931,19 @@ export class Game {
     }
   }
 
-  // TODO: We currently always do earthquake/postround to team 1, and then team 2.
-  // But it's probably random or something?
   private doPostRound() {
-    const aliveTeam1 = this.team1.getAliveMonsters();
-    const aliveTeam2 = this.team2.getAliveMonsters();
+    let aliveTeam1 = this.team1.getAliveMonsters();
+    let aliveTeam2 = this.team2.getAliveMonsters();
 
-    // TODO: Does this always go before poison?
     if (this.rulesets.has(Ruleset.EARTHQUAKE)) {
       this.doPostRoundEarthquake(aliveTeam1);
       this.doPostRoundEarthquake(aliveTeam2);
+      aliveTeam1 = this.team1.getAliveMonsters();
+      aliveTeam2 = this.team2.getAliveMonsters();
     }
-    // TODO: This is wrong, we should be checking maybeDead after each individual
-    // onPostRound damage done.
-    this.team1.monstersOnPostRound();
-    this.team2.monstersOnPostRound();
-    aliveTeam1.forEach((monster) => this.maybeDead(monster));
-    aliveTeam2.forEach((monster) => this.maybeDead(monster));
+
+    this.monstersOnPostRound(aliveTeam1);
+    this.monstersOnPostRound(aliveTeam2);
   }
 
   private doPostRoundEarthquake(aliveMonsters: GameMonster[]) {
@@ -964,6 +960,16 @@ export class Game {
       this.checkAndSetGameWinner();
       if (this.winner !== undefined) {
         return;
+      }
+    }
+  }
+
+  private monstersOnPostRound(aliveMonsters: GameMonster[]) {
+    for (const monster of aliveMonsters) {
+      if (monster.hasDebuff(Ability.POISON)) {
+        monster.health = monster.health - abilityUtils.POISON_DAMAGE;
+        this.createAndAddBattleLog(monster, Ability.POISON, undefined, abilityUtils.POISON_DAMAGE);
+        monster.setHasTurnPassed(false);
       }
     }
   }
@@ -1051,6 +1057,4 @@ export class Game {
     };
     this.battleLogs.push(log);
   }
-
-  private addMultipleBattleLogs(logs: BattleLog[]) {}
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,6 +1,14 @@
 import { GameTeam } from './game_team';
 import * as rulesetUtils from './utils/ruleset_utils';
-import { Ability, AttackType, BattleDamage, Ruleset } from './types';
+import {
+  Ability,
+  AdditionalBattleAction,
+  AttackType,
+  BattleDamage,
+  BattleLog,
+  BattleLogAction,
+  Ruleset,
+} from './types';
 import { GameSummoner } from './game_summoner';
 import { GameMonster } from './game_monster';
 import {
@@ -22,16 +30,24 @@ export class Game {
   private readonly team1: GameTeam;
   private readonly team2: GameTeam;
   private readonly rulesets: Set<Ruleset>;
+  private readonly battleLogs: BattleLog[] = [];
+  private readonly shouldLog: boolean;
   // 0 = tie
   // 1 = team1
   // 2 = team2
   private winner: number | undefined;
   private deadMonsters: GameMonster[] = [];
   private roundNumber = 0;
-  constructor(team1: GameTeam, team2: GameTeam, rulesets: Set<Ruleset>) {
+  constructor(
+    team1: GameTeam,
+    team2: GameTeam,
+    rulesets: Set<Ruleset>,
+    shouldLog: boolean = false,
+  ) {
     this.team1 = team1;
     this.team2 = team2;
     this.rulesets = rulesets;
+    this.shouldLog = shouldLog;
   }
 
   public getWinner() {
@@ -69,6 +85,10 @@ export class Game {
     this.team1.setAllMonsterHealth();
     this.team2.setAllMonsterHealth();
     this.playRoundsUntilGameEnd();
+  }
+
+  public getBattleLogs() {
+    return this.battleLogs;
   }
 
   // Add all summoner abilities which are in SUMMONER_BUFF_ABILITIES
@@ -171,18 +191,26 @@ export class Game {
     if (summoner.hasAbility(Ability.CLEANSE)) {
       const firstMonster = team.getFirstAliveMonster();
       firstMonster.cleanseDebuffs();
+      this.createAndAddBattleLog(summoner, Ability.CLEANSE, firstMonster);
     }
     if (summoner.hasAbility(Ability.REPAIR)) {
       const repairTarget = team.getRepairTarget();
-      abilityUtils.repairMonsterArmor(repairTarget);
+      if (repairTarget) {
+        abilityUtils.repairMonsterArmor(repairTarget);
+        this.createAndAddBattleLog(summoner, Ability.REPAIR, repairTarget || undefined);
+      }
     }
     if (summoner.hasAbility(Ability.TANK_HEAL)) {
       const firstMonster = team.getFirstAliveMonster();
       abilityUtils.tankHealMonster(firstMonster);
+      this.createAndAddBattleLog(summoner, Ability.TANK_HEAL, firstMonster || undefined);
     }
     if (summoner.hasAbility(Ability.TRIAGE)) {
       const healTarget = team.getTriageHealTarget();
-      abilityUtils.triageHealMonster(healTarget);
+      if (healTarget) {
+        const healAmt = abilityUtils.triageHealMonster(healTarget);
+        this.createAndAddBattleLog(summoner, Ability.TRIAGE, healTarget, healAmt);
+      }
     }
   }
 
@@ -193,23 +221,32 @@ export class Game {
     if (monster.hasAbility(Ability.CLEANSE)) {
       const cleanseTarget = friendlyTeam.getFirstAliveMonster();
       cleanseTarget.cleanseDebuffs();
+      this.createAndAddBattleLog(monster, Ability.CLEANSE, cleanseTarget);
     }
     if (monster.hasAbility(Ability.TANK_HEAL)) {
       const tankHealTarget = friendlyTeam.getFirstAliveMonster();
-      abilityUtils.tankHealMonster(tankHealTarget);
+      const healAmt = abilityUtils.tankHealMonster(tankHealTarget);
+      this.createAndAddBattleLog(monster, Ability.TANK_HEAL, tankHealTarget, healAmt);
     }
     if (monster.hasAbility(Ability.REPAIR)) {
       const friendlyGameTeam = this.getTeamOfMonster(monster);
       const repairTarget = friendlyGameTeam.getRepairTarget();
-      abilityUtils.repairMonsterArmor(repairTarget);
+      if (repairTarget) {
+        const repairAmt = abilityUtils.repairMonsterArmor(repairTarget);
+        this.createAndAddBattleLog(monster, Ability.REPAIR, repairTarget, repairAmt);
+      }
     }
     if (monster.hasAbility(Ability.TRIAGE)) {
       const friendlyGameTeam = this.getTeamOfMonster(monster);
       const triageTarget = friendlyGameTeam.getTriageHealTarget();
-      abilityUtils.triageHealMonster(triageTarget);
+      if (triageTarget) {
+        const healAmt = abilityUtils.triageHealMonster(triageTarget);
+        this.createAndAddBattleLog(monster, Ability.TRIAGE, triageTarget, healAmt);
+      }
     }
     if (monster.hasAbility(Ability.HEAL)) {
-      abilityUtils.selfHeal(monster);
+      const healAmt = abilityUtils.selfHeal(monster);
+      this.createAndAddBattleLog(monster, Ability.HEAL, monster, healAmt);
     }
   }
 
@@ -286,8 +323,18 @@ export class Game {
       !this.rulesets.has(Ruleset.AIM_TRUE) &&
       gameUtils.getDidDodge(this.rulesets, attackingMonster, attackTarget, attackType)
     ) {
+      this.createAndAddBattleLog(attackingMonster, Ability.DODGE, attackTarget);
       if (attackTarget.hasAbility(Ability.BACKFIRE)) {
-        damageUtils.hitMonsterWithPhysical(attackingMonster, abilityUtils.BACKFIRE_DAMAGE);
+        const battleDamage = damageUtils.hitMonsterWithPhysical(
+          attackingMonster,
+          abilityUtils.BACKFIRE_DAMAGE,
+        );
+        this.createAndAddBattleLog(
+          attackingMonster,
+          Ability.BACKFIRE,
+          attackTarget,
+          battleDamage.damageDone,
+        );
       }
       this.maybeDead(attackingMonster);
       return;
@@ -336,6 +383,7 @@ export class Game {
     }
 
     const battleDamage = this.actuallyHitMonster(attackingMonster, attackTarget, attackType);
+    this.createAndAddBattleLog(attackingMonster, attackType, attackTarget, battleDamage.damageDone);
 
     // Pierce
     if (attackingMonster.hasAbility(Ability.PIERCING) && battleDamage.remainder > 0) {
@@ -377,8 +425,15 @@ export class Game {
     // Affliction
     if (
       attackingMonster.hasAbility(Ability.AFFLICTION) &&
+      !attackTarget.hasDebuff(Ability.AFFLICTION) &&
       gameUtils.getSuccessBelow(abilityUtils.AFFLICTION_CHANCE * 100)
     ) {
+      this.createAndAddBattleLog(
+        attackingMonster,
+        Ability.AFFLICTION,
+        attackTarget,
+        battleDamage.damageDone,
+      );
       this.addMonsterToMonsterDebuff(attackingMonster, attackTarget, Ability.AFFLICTION);
     }
 
@@ -527,7 +582,12 @@ export class Game {
     const blastDamage = Math.ceil(damageDone / 2);
     if (attackType === AttackType.MAGIC) {
       const battleDamage = damageUtils.hitMonsterWithMagic(monsterToBlast, blastDamage);
-
+      this.createAndAddBattleLog(
+        attackingMonster,
+        Ability.BLAST,
+        monsterToBlast,
+        battleDamage.damageDone,
+      );
       this.maybeApplyMagicReflect(
         attackingMonster,
         monsterToBlast,
@@ -537,7 +597,12 @@ export class Game {
       this.maybeLifeLeech(attackingMonster, blastDamage - battleDamage.remainder);
     } else {
       const battleDamage = damageUtils.hitMonsterWithPhysical(monsterToBlast, blastDamage);
-
+      this.createAndAddBattleLog(
+        attackingMonster,
+        Ability.BLAST,
+        monsterToBlast,
+        battleDamage.damageDone,
+      );
       this.maybeApplyReturnFire(attackingMonster, monsterToBlast, attackType, battleDamage.attack);
     }
     this.maybeDead(monsterToBlast);
@@ -549,6 +614,7 @@ export class Game {
       return;
     }
 
+    this.createAndAddBattleLog(monster, AdditionalBattleAction.DEATH);
     this.deadMonsters.push(monster);
     monster.setHasTurnPassed(true);
     // Monster just died!
@@ -607,12 +673,14 @@ export class Game {
       const deadMonsterIndex = this.deadMonsters.findIndex((deadMon) => deadMon === deadMonster);
       deadMonster.armor = deadMonster.startingArmor;
       this.deadMonsters.splice(deadMonsterIndex, 1);
+      this.createAndAddBattleLog(monster, Ability.RESURRECT, monster);
     }
   }
 
   private onDeath(monster: GameMonster, deadMonster: GameMonster) {
     if (monster.hasAbility(Ability.SCAVENGER)) {
       monster.addBuff(Ability.SCAVENGER);
+      this.createAndAddBattleLog(monster, Ability.SCAVENGER, deadMonster);
     }
   }
 
@@ -626,6 +694,12 @@ export class Game {
         ? abilityUtils.THORNS_DAMAGE + 1
         : abilityUtils.THORNS_DAMAGE;
       const battleDamage = damageUtils.hitMonsterWithPhysical(attackingMonster, thornsDamage);
+      this.createAndAddBattleLog(
+        attackTarget,
+        Ability.THORNS,
+        attackingMonster,
+        battleDamage.damageDone,
+      );
     }
   }
 
@@ -647,6 +721,12 @@ export class Game {
       reflectDamage++;
     }
     const battleDamage = damageUtils.hitMonsterWithMagic(attackingMonster, reflectDamage);
+    this.createAndAddBattleLog(
+      attackTarget,
+      Ability.MAGIC_REFLECT,
+      attackingMonster,
+      battleDamage.damageDone,
+    );
   }
 
   private maybeApplyReturnFire(
@@ -667,6 +747,12 @@ export class Game {
       reflectDamage++;
     }
     const battleDamage = damageUtils.hitMonsterWithPhysical(attackingMonster, reflectDamage);
+    this.createAndAddBattleLog(
+      attackTarget,
+      Ability.RETURN_FIRE,
+      attackingMonster,
+      battleDamage.damageDone,
+    );
   }
 
   private maybeRetaliate(
@@ -681,6 +767,7 @@ export class Game {
     ) {
       return;
     }
+    this.createAndAddBattleLog(attackTarget, Ability.RETALIATE, attackingMonster);
     this.attackMonsterPhase(attackTarget, attackingMonster, AttackType.MELEE);
   }
 
@@ -707,12 +794,14 @@ export class Game {
   private maybeApplyCripple(attackingMonster: GameMonster, attackTarget: GameMonster) {
     if (attackingMonster.hasAbility(Ability.CRIPPLE) && attackTarget.isAlive()) {
       this.addMonsterToMonsterDebuff(attackingMonster, attackTarget, Ability.CRIPPLE);
+      this.createAndAddBattleLog(attackingMonster, Ability.CRIPPLE, attackTarget);
     }
   }
 
   private maybeApplyHalving(attackingMonster: GameMonster, attackTarget: GameMonster) {
     if (attackingMonster.hasAbility(Ability.HALVING) && !attackTarget.hasDebuff(Ability.HALVING)) {
       this.addMonsterToMonsterDebuff(attackingMonster, attackTarget, Ability.HALVING);
+      this.createAndAddBattleLog(attackingMonster, Ability.HALVING, attackTarget);
     }
   }
 
@@ -736,6 +825,7 @@ export class Game {
     const speedChange = isReverseSpeed ? -1 : 1;
     attackingMonster.speed += speedChange;
     attackingMonster.health += 1;
+    this.createAndAddBattleLog(attackingMonster, Ability.BLOODLUST);
   }
 
   private maybeLifeLeech(attackingMonster: GameMonster, damage: number) {
@@ -744,6 +834,7 @@ export class Game {
       for (let i = 0; i < lifeLeechAmt; i++) {
         attackingMonster.addBuff(Ability.LIFE_LEECH);
       }
+      this.createAndAddBattleLog(attackingMonster, Ability.LIFE_LEECH, undefined, lifeLeechAmt);
     }
   }
 
@@ -861,7 +952,14 @@ export class Game {
 
   private doPostRoundEarthquake(aliveMonsters: GameMonster[]) {
     for (const monster of aliveMonsters) {
-      rulesetUtils.applyEarthquake(monster);
+      const battleDamage = rulesetUtils.applyEarthquake(monster);
+      this.createAndAddBattleLog(
+        monster,
+        AdditionalBattleAction.EARTHQUAKE,
+        undefined,
+        battleDamage.damageDone,
+      );
+
       this.maybeDead(monster);
       this.checkAndSetGameWinner();
       if (this.winner !== undefined) {
@@ -896,6 +994,7 @@ export class Game {
     debuff: Ability,
   ) {
     monsterAffected.addDebuff(debuff);
+    this.createAndAddBattleLog(monsterThatApplied, debuff, monsterAffected);
   }
 
   private applyDebuffToMonsters(monsters: GameMonster[], debuff: Ability) {
@@ -910,10 +1009,12 @@ export class Game {
     }
   }
 
+  // TODO: this hits all of team 1 then 2, but team order should random
   private fatigueMonsters(roundNumber: number) {
     const fatigueDamage = roundNumber - FATIGUE_ROUND_NUMBER + 1;
     const allAliveMonsters = this.team1.getAliveMonsters().concat(this.team2.getAliveMonsters());
     for (const monster of allAliveMonsters) {
+      this.createAndAddBattleLog(monster, AdditionalBattleAction.FATIGUE, undefined, fatigueDamage);
       monster.hitHealth(fatigueDamage);
       this.maybeDead(monster);
     }
@@ -930,4 +1031,26 @@ export class Game {
   private getEnemyTeamOfMonster(monster: GameMonster): GameTeam {
     return monster.getTeamNumber() === 1 ? this.team2 : this.team1;
   }
+
+  private createAndAddBattleLog(
+    cardOne: GameCard,
+    action: BattleLogAction,
+    cardTwo?: GameCard,
+    value?: number,
+  ) {
+    if (!this.shouldLog) {
+      return;
+    }
+    const actor = cardOne.clone();
+    const target = cardTwo ? cardTwo.clone() : undefined;
+    const log = {
+      actor,
+      action,
+      target,
+      value,
+    };
+    this.battleLogs.push(log);
+  }
+
+  private addMultipleBattleLogs(logs: BattleLog[]) {}
 }

--- a/src/game_card.ts
+++ b/src/game_card.ts
@@ -1,7 +1,7 @@
 import { CardDetail, CardStats, TEAM_NUMBER } from './types';
 import { Ability } from './types';
 
-export abstract class GameCard {
+export class GameCard {
   private readonly cardDetail: CardDetail;
   private readonly cardLevel: number;
   private team: number = TEAM_NUMBER.UNKNOWN;
@@ -44,12 +44,29 @@ export abstract class GameCard {
     return this.team;
   }
 
-  getRarity(): number {
+  public getRarity(): number {
     return this.cardDetail.rarity;
   }
 
   public getName(): string {
     return this.cardDetail.name;
+  }
+
+  public clone(): GameCard {
+    const clonedCard = new GameCard(this.cardDetail, this.cardLevel);
+    clonedCard.abilities = new Set(this.abilities);
+    clonedCard.speed = this.speed;
+    clonedCard.startingArmor = this.startingArmor;
+    clonedCard.armor = this.armor;
+    clonedCard.startingHealth = this.startingHealth;
+    clonedCard.health = this.health;
+    clonedCard.magic = this.magic;
+    clonedCard.melee = this.melee;
+    clonedCard.ranged = this.ranged;
+    clonedCard.mana = this.mana;
+    clonedCard.setTeam(this.team);
+
+    return clonedCard;
   }
 
   private setStats(stats: CardStats) {

--- a/src/game_monster.ts
+++ b/src/game_monster.ts
@@ -57,16 +57,6 @@ export class GameMonster extends GameCard {
     return this.cardPosition;
   }
 
-  onPostRound() {
-    if (this.health <= 0) {
-      return;
-    }
-    this.hasTurnPassed = false;
-    if (this.hasDebuff(Ability.POISON)) {
-      this.health = this.health - abilityUtils.POISON_DAMAGE;
-    }
-  }
-
   isAlive() {
     return this.health > 0;
   }

--- a/src/game_team.ts
+++ b/src/game_team.ts
@@ -23,10 +23,6 @@ export class GameTeam {
     }
   }
 
-  public monstersOnPostRound() {
-    this.monsterList.forEach((monster) => monster.onPostRound());
-  }
-
   /** Position of the alive monsters */
   public getMonsterPosition(monster: GameMonster): number {
     return this.getAliveMonsters().findIndex((m) => m === monster);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { GameCard } from './game_card';
+
 // Things for the battle
 export interface Team {
   summoner: CardDetail;
@@ -301,4 +303,26 @@ export enum TEAM_NUMBER {
   UNKNOWN = 0,
   FRIENDLY = 1,
   ENEMY = 2,
+}
+
+export enum AdditionalBattleAction {
+  DEATH = 3,
+  EARTHQUAKE,
+  FATIGUE,
+  MELEE,
+  RANGED,
+  MAGIC,
+}
+
+export type BattleLogAction = Ability | AdditionalBattleAction | AttackType;
+
+export interface BattleLog {
+  /** The summoner or monster performing the action. This is a snapshot of the actor AFTER the action has been performed. */
+  actor: GameCard;
+  /** The target of the action. This is a snapshot of the target AFTER the action has been performed. */
+  target?: GameCard;
+  /** The action */
+  action: BattleLogAction;
+  /** The value, can be the amount of damage, or heal, etc. Based on the action */
+  value?: number;
 }

--- a/src/utils/ruleset_utils.ts
+++ b/src/utils/ruleset_utils.ts
@@ -1,7 +1,7 @@
 import { GameMonster } from '../game_monster';
 import { GameSummoner } from '../game_summoner';
 import { GameTeam } from '../game_team';
-import { Ability, Ruleset } from '../types';
+import { Ability, BattleDamage, Ruleset } from '../types';
 import { EARTHQUAKE_DAMAGE } from './ability_utils';
 import { hitMonsterWithPhysical } from './damage_utils';
 
@@ -92,10 +92,15 @@ function applyCloseRangeRuleset(monster: GameMonster) {
 }
 
 /** Do 2 physical damage to monsters that don't have flying ability */
-export function applyEarthquake(monster: GameMonster) {
+export function applyEarthquake(monster: GameMonster): BattleDamage {
   if (!monster.hasAbility(Ability.FLYING) || monster.hasDebuff(Ability.SNARE)) {
-    hitMonsterWithPhysical(monster, EARTHQUAKE_DAMAGE);
+    return hitMonsterWithPhysical(monster, EARTHQUAKE_DAMAGE);
   }
+  return {
+    attack: 0,
+    damageDone: 0,
+    remainder: 0,
+  };
 }
 
 /**


### PR DESCRIPTION
Add battle logs to Game. Logs are not enabled by default and enabling logs must be set when constructing the Game.

Each battle action is logged and the GameCard that is returned  is a snapshot of the card AFTER the action has ocurred.