### PR TITLE
Update to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splinterlands-simulator",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Simulator for battles in the Splinterlands game",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION

Show the correct resurrect monster.
Add buff and debuff map to GameCard so it can be accessed from the battle logs.