### PR TITLE
2.1.7 - Amplify is not a debuff.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splinterlands-simulator",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Simulator for battles in the Splinterlands game",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/game_monster.ts
+++ b/src/game_monster.ts
@@ -131,7 +131,10 @@ export class GameMonster extends GameCard {
     if (!this.isAlive()) {
       return;
     }
-    if (this.abilities.has(Ability.IMMUNITY)) {
+    if (
+      this.abilities.has(Ability.IMMUNITY) &&
+      abilityUtils.UNCLEANSABLE_DEBUFFS.indexOf(debuff) < 0
+    ) {
       return;
     }
     if (debuff === Ability.SNARE && this.hasDebuff(Ability.SNARE)) {
@@ -179,7 +182,9 @@ export class GameMonster extends GameCard {
     // Special case, cleanse only removes 1 cripple
     const crippleAmt = this.getDebuffAmt(Ability.CRIPPLE);
     this.debuffsMap.forEach((value, key) => {
-      this.removeAllDebuff(key);
+      if (abilityUtils.UNCLEANSABLE_DEBUFFS.indexOf(key) > -1) {
+        this.removeAllDebuff(key);
+      }
     });
     if (crippleAmt > 1) {
       this.debuffsMap.set(Ability.CRIPPLE, crippleAmt - 1);

--- a/src/utils/ability_utils.ts
+++ b/src/utils/ability_utils.ts
@@ -77,6 +77,12 @@ export const MONSTER_DEBUFF_ABILITIES = [
   Ability.WEAKEN,
 ];
 
+/**
+ * Abilities that can't be cleansed. (These aren't actually debuffs but this app codes them as a debuff)
+ * https://support.splinterlands.com/hc/en-us/articles/4414966685332-Abilities-Status-Effects
+ */
+export const UNCLEANSABLE_DEBUFFS = [Ability.AMPLIFY];
+
 /** Abilities that require a turn to do something */
 export const ACTION_ABILITIES = [Ability.REPAIR, Ability.TANK_HEAL];
 


### PR DESCRIPTION
Amplify can't be cleansed