### PR TITLE
last stand stats should be rounded down

### DIFF
--- a/src/game_monster.ts
+++ b/src/game_monster.ts
@@ -313,7 +313,7 @@ export class GameMonster extends GameCard {
   getPostAbilityMaxArmor() {
     let maxArmor = this.startingArmor;
     if (this.getIsLastStand()) {
-      maxArmor = Math.ceil(maxArmor * abilityUtils.LAST_STAND_MULTIPLIER);
+      maxArmor = Math.floor(maxArmor * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     if (this.hasBuff(Ability.PROTECT)) {
       const protectAmt = this.getBuffAmt(Ability.PROTECT);
@@ -331,7 +331,7 @@ export class GameMonster extends GameCard {
     let speedModifier = 0;
     let speed = this.speed + this.summonerSpeed;
     if (this.getIsLastStand()) {
-      speed = Math.ceil(speed * abilityUtils.LAST_STAND_MULTIPLIER);
+      speed = Math.floor(speed * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     if (this.isEnraged()) {
       speed = Math.ceil(speed * abilityUtils.ENRAGE_MULTIPLIER);
@@ -363,7 +363,7 @@ export class GameMonster extends GameCard {
       maxHealth = maxHealth - abilityUtils.CRIPPLE_AMOUNT * crippleAmt;
     }
     if (this.getIsLastStand()) {
-      maxHealth = Math.ceil(maxHealth * abilityUtils.LAST_STAND_MULTIPLIER);
+      maxHealth = Math.floor(maxHealth * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     if (this.hasDebuff(Ability.WEAKEN)) {
       const weakenAmt = this.getDebuffAmt(Ability.WEAKEN);
@@ -404,7 +404,7 @@ export class GameMonster extends GameCard {
       postMagic = Math.floor((postMagic + 1) / 2);
     }
     if (this.getIsLastStand()) {
-      postMagic = Math.ceil(postMagic * abilityUtils.LAST_STAND_MULTIPLIER);
+      postMagic = Math.floor(postMagic * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     let magicModifier = 0;
     for (let i = 0; i < this.getDebuffAmt(Ability.SILENCE); i++) {
@@ -428,7 +428,7 @@ export class GameMonster extends GameCard {
       postRange = Math.floor((postRange + 1) / 2);
     }
     if (this.getIsLastStand()) {
-      postRange = Math.ceil(postRange * abilityUtils.LAST_STAND_MULTIPLIER);
+      postRange = Math.floor(postRange * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     let rangeModifier = 0;
     // TODO(Headwinds) Does this stack?
@@ -454,7 +454,7 @@ export class GameMonster extends GameCard {
       postMelee = Math.floor((postMelee + 1) / 2);
     }
     if (this.getIsLastStand()) {
-      postMelee = Math.ceil(postMelee * abilityUtils.LAST_STAND_MULTIPLIER);
+      postMelee = Math.floor(postMelee * abilityUtils.LAST_STAND_MULTIPLIER);
     }
     let meleeModifier = 0;
     if (this.hasBuff(Ability.INSPIRE)) {


### PR DESCRIPTION
Last stand will increase all stats of a creature by 50% (rounded down) when the creature is the last standing member.

https://support.splinterlands.com/hc/en-us/articles/4414966685332-Abilities-Status-Effects
search "last stand" on this page for more detail