### PR TITLE
2.1.11 Add void armor to summoner skills. Replay games without having to remake teams.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splinterlands-simulator",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Simulator for battles in the Splinterlands game",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/game.ts
+++ b/src/game.ts
@@ -59,7 +59,7 @@ export class Game {
   }
 
   public playGame() {
-    this.roundNumber = 0;
+    this.reset();
     const team1Summoner = this.team1.getSummoner();
     const team1Monsters = this.team1.getMonstersList();
     const team2Summoner = this.team2.getSummoner();
@@ -98,6 +98,14 @@ export class Game {
       );
     }
     return this.battleLogs;
+  }
+
+  private reset() {
+    this.roundNumber = 0;
+    this.winner = undefined;
+    this.deadMonsters = [];
+    this.team1.resetTeam();
+    this.team2.resetTeam();
   }
 
   // Add all summoner abilities which are in SUMMONER_BUFF_ABILITIES

--- a/src/game_card.ts
+++ b/src/game_card.ts
@@ -39,6 +39,11 @@ export class GameCard {
     return this.cardDetail;
   }
 
+  /** Returns the card level (0 indexed) */
+  public getCardLevel(): number {
+    return this.cardLevel;
+  }
+
   public hasAbility(ability: Ability) {
     return this.abilities.has(ability);
   }
@@ -69,6 +74,10 @@ export class GameCard {
 
   public getBuffs(): Map<Ability, number> {
     return this.buffsMap;
+  }
+
+  public getCleanCard(): GameCard {
+    return new GameCard(this.cardDetail, this.cardLevel + 1);
   }
 
   public clone(): GameCard {

--- a/src/game_monster.ts
+++ b/src/game_monster.ts
@@ -488,6 +488,10 @@ export class GameMonster extends GameCard {
     this.cleanseDebuffs();
   }
 
+  public getCleanCard(): GameMonster {
+    return new GameMonster(this.getCardDetail(), this.getCardLevel() + 1);
+  }
+
   /********************* Things regarding abilities? ********************/
   private isEnraged() {
     return this.hasAbility(Ability.ENRAGE) && this.health < this.getPostAbilityMaxHealth();

--- a/src/game_team.ts
+++ b/src/game_team.ts
@@ -3,8 +3,9 @@ import { GameSummoner } from './game_summoner';
 import { Ability, TeamNumber } from './types';
 
 export class GameTeam {
-  private readonly summoner: GameSummoner;
-  private readonly monsterList: GameMonster[];
+  private summoner: GameSummoner;
+  private monsterList: GameMonster[];
+  private teamNumber: TeamNumber | undefined;
 
   constructor(summoner: GameSummoner, monsterList: GameMonster[]) {
     this.summoner = summoner;
@@ -21,7 +22,19 @@ export class GameTeam {
     }
   }
 
+  public resetTeam() {
+    this.summoner = this.summoner.getCleanCard();
+    this.monsterList = this.monsterList.map((card) => card.getCleanCard() as GameMonster);
+    this.setMonsterPositions();
+    if (this.teamNumber) {
+      this.setTeam(this.teamNumber);
+    } else {
+      throw new Error('Team must have a team number set');
+    }
+  }
+
   public setTeam(teamNumber: TeamNumber) {
+    this.teamNumber = teamNumber;
     this.summoner.setTeam(teamNumber);
     this.monsterList.forEach((monster) => monster.setTeam(teamNumber));
   }
@@ -64,7 +77,7 @@ export class GameTeam {
     }
   }
 
-  getScattershotTarget(): GameMonster {
+  public getScattershotTarget(): GameMonster {
     const aliveMonsters = this.getAliveMonsters();
     const randomMonsterNum = Math.floor(Math.random() * aliveMonsters.length);
     return aliveMonsters[randomMonsterNum];

--- a/src/utils/ability_utils.ts
+++ b/src/utils/ability_utils.ts
@@ -47,6 +47,7 @@ export const SUMMONER_ABILITY_ABILITIES = [
   Ability.SNARE,
   Ability.THORNS,
   Ability.TRUE_STRIKE,
+  Ability.VOID_ARMOR,
   Ability.VOID,
   Ability.POISON,
 ];

--- a/src/utils/ability_utils.ts
+++ b/src/utils/ability_utils.ts
@@ -37,7 +37,6 @@ export const ENRAGE_MULTIPLIER = 1.5;
 
 /** Abilities that summoner gives to friendly team at the start of the game */
 export const SUMMONER_ABILITY_ABILITIES = [
-  Ability.AMPLIFY,
   Ability.BLAST,
   Ability.DIVINE_SHIELD,
   Ability.FLYING,
@@ -56,7 +55,7 @@ export const SUMMONER_ABILITY_ABILITIES = [
 export const SUMMONER_BUFF_ABILITIES = [Ability.STRENGTHEN];
 
 /** Abilities that summoner applies to enemy team at the start of the game */
-export const SUMMONER_DEBUFF_ABILITIES = [Ability.AFFLICTION, Ability.BLIND];
+export const SUMMONER_DEBUFF_ABILITIES = [Ability.AFFLICTION, Ability.AMPLIFY, Ability.BLIND];
 
 /** Abilities that monsters apply to friendly team at the start of the game */
 export const MONSTER_BUFF_ABILITIES = [


### PR DESCRIPTION
Add void armor to summoner skills. 
Replay games without having to remake teams. Can just call `playGame()` over and over again.